### PR TITLE
Minor ui fixes in GWTConfigPanelVisual

### DIFF
--- a/trunk/src/org/netbeans/modules/gwt4nb/Bundle.properties
+++ b/trunk/src/org/netbeans/modules/gwt4nb/Bundle.properties
@@ -40,11 +40,11 @@ ERROR_Select_GWT_Folder=Select Google Web Toolkit installation folder.
 ERROR_Invalid_GWT_Module_Name=Invalid GWT Module name.
 ERROR_Invalid_GWT_Folder=The selected folder is not a valid Google Web Toolkit installation folder.
 
-GWTConfigPanelVisual.lblGWTModule.text=GWT Module\:
+GWTConfigPanelVisual.lblGWTModule.text=GWT &Module:
 
-GWTConfigPanelVisual.btnGWTBrowse.text=Browse
+GWTConfigPanelVisual.btnGWTBrowse.text=&Browse...
 
-GWTConfigPanelVisual.lblGWTFolder.text=GWT SDK Installation Folder:
+GWTConfigPanelVisual.lblGWTFolder.text=GWT SDK &Location:
 GWTConfigPanelVisual.gwtModule.text=org.yournamehere.Main
 Templates/GWT/GWT_Constants=GWT Constants
 NewConstantsPanelVisual.lblLocalIFace.text=Properties File:
@@ -63,7 +63,7 @@ NewModulePanelVisual.lblServiceName.text=Fully Qualified Module Name:
 NewModulePanelVisual.jCheckBoxClient.text=Create Client Package
 NewModulePanelVisual.jCheckBoxServer.text=Create Server Package
 NewModulePanelVisual.jCheckBoxPublic.text=Create Public Package
-GWTConfigPanelVisual.jLabel1.text=<html>You can download the GWT SDK <u><font color="0000FF">here</font></u></html>
+GWTConfigPanelVisual.jLabel1.text=<html>You can download the GWT SDK <u><a href="#">here</a></u></html>
 GWTConfigPanelVisual.jLabel2.text=You can change GWT SDK location from the projects window
 SettingsPanel.jTextField1.text=
 CTL_RunGWTDevMode=Run GWT DevMode

--- a/trunk/src/org/netbeans/modules/gwt4nb/GWTConfigPanelVisual.form
+++ b/trunk/src/org/netbeans/modules/gwt4nb/GWTConfigPanelVisual.form
@@ -4,7 +4,7 @@
   <AuxValues>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
-    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="2"/>
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
@@ -15,14 +15,10 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="1" attributes="0">
-              <EmptySpace pref="521" max="32767" attributes="0"/>
-              <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-          </Group>
           <Group type="102" attributes="0">
               <Component id="lblGWTFolder" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="gwtFolder" pref="485" max="32767" attributes="2"/>
+              <Component id="gwtFolder" pref="518" max="32767" attributes="2"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="btnGWTBrowse" min="-2" max="-2" attributes="0"/>
           </Group>
@@ -32,9 +28,12 @@
               <Component id="gwtModule" min="-2" pref="234" max="-2" attributes="1"/>
               <EmptySpace pref="398" max="32767" attributes="0"/>
           </Group>
-          <Group type="102" attributes="0">
-              <EmptySpace pref="411" max="32767" attributes="0"/>
-              <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+          <Group type="102" alignment="1" attributes="0">
+              <EmptySpace max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jLabel1" alignment="1" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel2" alignment="1" min="-2" max="-2" attributes="0"/>
+              </Group>
           </Group>
       </Group>
     </DimensionLayout>

--- a/trunk/src/org/netbeans/modules/gwt4nb/GWTConfigPanelVisual.java
+++ b/trunk/src/org/netbeans/modules/gwt4nb/GWTConfigPanelVisual.java
@@ -80,9 +80,9 @@ public class GWTConfigPanelVisual extends javax.swing.JPanel {
 
         lblGWTFolder.setLabelFor(gwtFolder);
         java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("org/netbeans/modules/gwt4nb/Bundle"); // NOI18N
-        lblGWTFolder.setText(bundle.getString("GWTConfigPanelVisual.lblGWTFolder.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(lblGWTFolder, bundle.getString("GWTConfigPanelVisual.lblGWTFolder.text")); // NOI18N
 
-        btnGWTBrowse.setText(bundle.getString("GWTConfigPanelVisual.btnGWTBrowse.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(btnGWTBrowse, bundle.getString("GWTConfigPanelVisual.btnGWTBrowse.text")); // NOI18N
         btnGWTBrowse.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnGWTBrowsebrowse(evt);
@@ -90,18 +90,18 @@ public class GWTConfigPanelVisual extends javax.swing.JPanel {
         });
 
         lblGWTModule.setLabelFor(gwtModule);
-        lblGWTModule.setText(bundle.getString("GWTConfigPanelVisual.lblGWTModule.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(lblGWTModule, bundle.getString("GWTConfigPanelVisual.lblGWTModule.text")); // NOI18N
 
         gwtModule.setText(org.openide.util.NbBundle.getMessage(GWTConfigPanelVisual.class, "GWTConfigPanelVisual.gwtModule.text")); // NOI18N
 
-        jLabel1.setText(org.openide.util.NbBundle.getMessage(GWTConfigPanelVisual.class, "GWTConfigPanelVisual.jLabel1.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(GWTConfigPanelVisual.class, "GWTConfigPanelVisual.jLabel1.text")); // NOI18N
         jLabel1.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 jLabel1MouseClicked(evt);
             }
         });
 
-        jLabel2.setText(org.openide.util.NbBundle.getMessage(GWTConfigPanelVisual.class, "GWTConfigPanelVisual.jLabel2.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel2, org.openide.util.NbBundle.getMessage(GWTConfigPanelVisual.class, "GWTConfigPanelVisual.jLabel2.text")); // NOI18N
         jLabel2.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 jLabel2MouseClicked(evt);
@@ -112,13 +112,10 @@ public class GWTConfigPanelVisual extends javax.swing.JPanel {
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
-                .addContainerGap(521, Short.MAX_VALUE)
-                .add(jLabel1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
             .add(layout.createSequentialGroup()
                 .add(lblGWTFolder)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(gwtFolder, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 485, Short.MAX_VALUE)
+                .add(gwtFolder, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 518, Short.MAX_VALUE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(btnGWTBrowse))
             .add(layout.createSequentialGroup()
@@ -126,9 +123,11 @@ public class GWTConfigPanelVisual extends javax.swing.JPanel {
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(gwtModule, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 234, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap(398, Short.MAX_VALUE))
-            .add(layout.createSequentialGroup()
-                .addContainerGap(411, Short.MAX_VALUE)
-                .add(jLabel2))
+            .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
+                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                    .add(org.jdesktop.layout.GroupLayout.TRAILING, jLabel1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .add(org.jdesktop.layout.GroupLayout.TRAILING, jLabel2)))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)


### PR DESCRIPTION
- added mnemonics
- aligned naming scheme of labels
- make link compatible to darkthemes (>=NB7.4, still works in NB7.3, hardcoded color was removed)

![2013-10-24_23h17_44](https://f.cloud.github.com/assets/1857095/1403794/4271cad4-3cf9-11e3-844b-e7aa8e83fb84.png)
