### PR TITLE
use custom nb build file name if defined

### DIFF
--- a/trunk/src/org/netbeans/modules/gwt4nb/RunDevGAEAction.java
+++ b/trunk/src/org/netbeans/modules/gwt4nb/RunDevGAEAction.java
@@ -176,10 +176,20 @@ public final class RunDevGAEAction extends ProjectAction {
                 DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(msg));
 
             } else {
-                FileObject buildFo = p.getProjectDirectory().
-                        getFileObject("build.xml"); // NOI18N
-
+                FileObject propertiesFile = p.getProjectDirectory().
+                getFileObject("nbproject/project.properties"); // NOI18N
+                
+                Properties properties = new Properties();
                 try {
+                    properties.load(propertiesFile.getInputStream());
+                    String buildFile = properties.getProperty(
+                            "buildfile"); // NOI18N
+                    if (buildFile == null) {
+                        buildFile = "build.xml"; // NOI18N
+                    }
+                    FileObject buildFo = p.getProjectDirectory().
+                        getFileObject(buildFile);
+
                     ActionUtils.runTarget(buildFo, new String[]{
                                 "gwt-devmode-on-appengine"}, null); // NOI18N
                 } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
Hi,

Default netbeans build file is "build.xml" but it can be changed using the "buildfile" property in the project.properties file.
If so, the RunDevGAEAction must use the proper build file or it fails.

Maybe there is other files with the same issue.

Hope it could help.

Regards,
Yann
