### PR TITLE
Fix: Corrected Build Target for GWT 2.7 (Issue #38)

### DIFF
--- a/trunk/src/org/netbeans/modules/gwt4nb/resources/build-gwt.xml
+++ b/trunk/src/org/netbeans/modules/gwt4nb/resources/build-gwt.xml
@@ -143,6 +143,7 @@ target, declare a new one with the same name in build.xml.
         <or>
             <equals arg1="${gwt.version}" arg2="2.5"/>
             <equals arg1="${gwt.version}" arg2="2.6"/>
+            <equals arg1="${gwt.version}" arg2="2.7"/>
         </or>
     </condition>
     


### PR DESCRIPTION
Fix for Issue #38 

Projects created with this plugin failed to build if used with GWT 2.7; though they would build if used with 2.6.1. This is because the build target for 2.7 was falling into the gwt.version.15 build target, which referenced a main class that no longer exists in 2.7.

The fix was to add a case to the gwt.version.25 property (which already covered 2.6) to cover version 2.7.  